### PR TITLE
default log level change from 1 to 6

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,7 +30,7 @@ pm2.Client.launchBus(function(err, bus) {
                 'host': hostname,
                 'timestamp': (log.at / 1000),
                 'short_message': log.data,
-                'level': 1,
+                'level': 6,
                 'facility': log.process.name
             };
             gelf.emit('gelf.log', message);


### PR DESCRIPTION
to avoid rfc issues with log level, 1 should be reserved for alerts, so i recommend changing default log level to be 6